### PR TITLE
ci: GitHub ActionsのCIワークフローを追加

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  push:
+    branches: ['main']
+  pull_request:
+    branches: ['main']
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: 'pnpm'
+          cache-dependency-path: pnpm-lock.yaml
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+        with:
+          version: 8.15.0
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Type check
+        run: pnpm type-check
+
+      - name: Test
+        run: pnpm test


### PR DESCRIPTION
## 概要
- GitHub ActionsでCIを追加
- pnpm install → lint → type-check → testのジョブを定義
- Node.jsのキャッシュを設定し実行時間を短縮

## テスト
- `pnpm codegen` で403エラーにより失敗
- `pnpm type-check` で型チェックエラーにより失敗
- `pnpm lint` でプラグイン未解決により失敗
- `pnpm test` はスクリプト未定義で失敗


------
https://chatgpt.com/codex/tasks/task_e_68ba9c4442ec83339b5119a6a012e914